### PR TITLE
Factor out the date format into a constant

### DIFF
--- a/handlers/bot.js
+++ b/handlers/bot.js
@@ -45,7 +45,7 @@ const handleEndDateAnswer = (response, convo) => {
 
 const startVacationRequestConversation = (bot, user) => {
   bot.startPrivateConversation({user: user}, (err, convo) => {
-    convo.addQuestion('Awesome. And what day will you be back? (Use dd/mm/yyyy again)',[
+    convo.addQuestion(`Awesome. And what day will you be back? (Use ${dateUtil.FORMAT} again)`,[
       {
         default: true,
         callback: (response, convo) => { handleEndDateAnswer(response, convo) }
@@ -124,35 +124,35 @@ const startVacationRequestConversation = (bot, user) => {
       }
     ],{},'do_you_want_to_try_again')
 
-    convo.addQuestion('Please provide the date in format dd/mm/yyyy (sorry, my boss is a stickler)',[
+    convo.addQuestion(`Please provide the date in format ${dateUtil.FORMAT} (sorry, my boss is a stickler)`,[
       {
         default: true,
         callback: (response, convo) => { handleStartDateAnswer(response, convo) }
       }
     ],{},'remind_start_date_format')
 
-    convo.addQuestion('Please provide the date in format dd/mm/yyyy (sorry, my boss is a stickler)',[
+    convo.addQuestion(`Please provide the date in format ${dateUtil.FORMAT} (sorry, my boss is a stickler)`, [
       {
         default: true,
         callback: (response, convo) => { handleEndDateAnswer(response, convo) }
       }
     ],{},'remind_end_date_format')
 
-    convo.addQuestion('Ok, let\'s try it again then. Please provide the start date in format dd/mm/yyyy',[
+    convo.addQuestion(`Ok, let's try it again then. Please provide the start date in format ${dateUtil.FORMAT}`, [
       {
         default: true,
         callback: (response, convo) => { handleStartDateAnswer(response, convo) }
       }
     ],{},'try_providing_start_date_again')
 
-    convo.addQuestion('Ok, let\'s try it again then. Please provide the end date in format dd/mm/yyyy',[
+    convo.addQuestion(`Ok, let's try it again then. Please provide the end date in format ${dateUtil.FORMAT}`, [
       {
         default: true,
         callback: (response, convo) => { handleEndDateAnswer(response, convo) }
       }
     ],{},'try_providing_end_date_again')
 
-    convo.addQuestion('Noice! I can update your Slack status (with a nice emoji) for you on the day you leave so you don\'t forget. What day will your vacation start? (Use the format: dd/mm/yyyy)',[
+    convo.addQuestion(`Noice! I can update your Slack status (with a nice emoji) for you on the day you leave so you don't forget. What day will your vacation start? (Use the format: ${dateUtil.FORMAT})`,[
       {
         default: true,
         callback: (response, convo) => { handleStartDateAnswer(response, convo) }

--- a/util/date.js
+++ b/util/date.js
@@ -1,3 +1,5 @@
+const FORMAT = 'dd/mm/yyyy'
+
 const getTodayDateObject = () => {
   const currentTime = new Date()
   const month = currentTime.getMonth() + 1
@@ -23,5 +25,6 @@ const guessDate = (dateFromAnswerValidated) => {
 export {
   getTodayDateObject,
   validate,
-  guessDate
+  guessDate,
+  FORMAT
 }


### PR DESCRIPTION
Not a big change, but thought it would be good to remove some duplication. Also puts the expected format in the same module as the function validating it, which will help if we ever want make the format more flexible in future.